### PR TITLE
Adding Rhel metering specific filtering examples

### DIFF
--- a/docs/aws/aws.rst
+++ b/docs/aws/aws.rst
@@ -177,44 +177,9 @@ Configure Athena
 
 1. Amazon strongly recommends using CloudFormation and provides instruction on how to do so `here <https://docs.aws.amazon.com/cur/latest/userguide/use-athena-cf.html>`_
 2. Make sure Athena is configured to store query results to the desired S3 bucket see `Querying <https://docs.aws.amazon.com/athena/latest/ug/querying.html>`_
-3. Once Athena is configured the following query will return the filtered dataset specific to your Red Hat commitment. The table name following the FROM keyword would be updated to match the name of the table configured in your Athena instance. The year and month can be updated to gather data specific to a particular month.
-
-.. code-block::
-
-    SELECT *
-    FROM athena_cost_and_usage
-    WHERE (
-            bill_billing_entity = 'AWS Marketplace'
-            AND line_item_legal_entity like '%Red Hat%'
-        )
-        OR (
-            line_item_legal_entity like '%Amazon Web Services%'
-            AND line_item_line_item_description like '%Red Hat%'
-        )
-        OR (
-            line_item_legal_entity like '%Amazon Web Services%'
-            AND line_item_line_item_description like '%RHEL%'
-        )
-        OR (
-            line_item_legal_entity like '%AWS%'
-            AND line_item_line_item_description like '%Red Hat%'
-        )
-        OR (
-            line_item_legal_entity like '%AWS%'
-            AND line_item_line_item_description like '%RHEL%'
-        )
-        OR (
-            line_item_legal_entity like '%AWS%'
-            AND product_product_name like '%Red Hat%'
-        )
-        OR (
-            line_item_legal_entity like '%Amazon Web Services%'
-            AND product_product_name like '%Red Hat%'
-        )
-        AND year = '2022'
-        AND month = '10'
-
-4. At this point you can download the query results directly to file from the Athena console, or reference the location of the saved result in S3†
+3. Once Athena is configured you can build a query to filter your data to select lineitems.
+4. See `Building an Athena Query`_
+5. At this point you can download the query results directly to file from the Athena console, or reference the location of the saved result in S3†
 
 
 Secrets Manager Credentials
@@ -277,3 +242,80 @@ a. Create EventBridge schedule for Athena query function
     xiv. Permissions: Create new role on the fly
     xv. NEXT
     xvi. Review and create
+
+
+
+Building an Athena Query
+========================
+
+* Examples:
+    1. **athena_cost_and_usage** This should match your table name in Athena.
+    2. **bill_billing_entity** Used to filter specific billing entities.
+    3. **line_item_legal_entity** Used to filter specifc legal entities.
+    4. **line_item_line_item_description** Used to filter on specific line item descriptions.
+    5. **year** Used to filter to a specific billing year.
+    6. **month** Used to filter on a specific billing month.
+* See the following example queires for HCS spend or RHEL ELS subscriptions.
+    * The table name **athena_cost_and_usage** MUST be updated to match the name of your configured Athena table.
+    * The **year** and **month** can be updated to gather data specific to a particular month.
+
+* The below example query will return filtered data specific for your Hybrid Commited Spend commitment.
+
+.. code-block::
+
+    SELECT *
+    FROM athena_cost_and_usage
+    WHERE (
+            bill_billing_entity = 'AWS Marketplace'
+            AND line_item_legal_entity like '%Red Hat%'
+        )
+        OR (
+            line_item_legal_entity like '%Amazon Web Services%'
+            AND line_item_line_item_description like '%Red Hat%'
+        )
+        OR (
+            line_item_legal_entity like '%Amazon Web Services%'
+            AND line_item_line_item_description like '%RHEL%'
+        )
+        OR (
+            line_item_legal_entity like '%AWS%'
+            AND line_item_line_item_description like '%Red Hat%'
+        )
+        OR (
+            line_item_legal_entity like '%AWS%'
+            AND line_item_line_item_description like '%RHEL%'
+        )
+        OR (
+            line_item_legal_entity like '%AWS%'
+            AND product_product_name like '%Red Hat%'
+        )
+        OR (
+            line_item_legal_entity like '%Amazon Web Services%'
+            AND product_product_name like '%Red Hat%'
+        )
+        AND year = '2024'
+        AND month = '07'
+
+
+* The below example query will return filtered data specific to your RHEL subscriptions
+    *  *Note:* you MUST change **resource_tags_user_tag_column** in the below query to match your RHEL tag column
+
+        .. code-block::
+
+            SELECT *
+            FROM athena_cost_and_usage
+            WHERE (
+                    line_item_product_code = 'AmazonEC2'
+                    AND strpos(lower(resource_tags_user_tag_column), 'com_redhat_rhel') > 0
+                )
+                AND year = '2024'
+                AND month = '07'
+
+    * Query to grab a list of all tagging columns
+
+        .. code-block::
+
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'athena_cost_and_usage'
+            AND column_name LIKE 'resource_tags_%';

--- a/docs/aws/aws.rst
+++ b/docs/aws/aws.rst
@@ -211,7 +211,6 @@ Secrets Manager Credentials
 Function Code and Athena Queries
 ================================
 * For standard Hybrid Commited Spend queries use the default `athena_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/aws/scripts/athena-query-function.txt>`_
-* For custom queries non HCS we need to edit line 18 in the above function code.
     * Initial query to grab all data: **query = f"SELECT * FROM {database}.{export_name} WHERE year = '{year}' AND month = '{month}'"**
     * To filter the data add a **WHERE** clause, for example **WHERE line_item_line_item_description LIKE '%Red Hat%'** would filter out all data that does not have a description containing Red Hat.
     * It's also possible to stack these by using **AND** and **OR** with your **WHERE** clause.
@@ -251,15 +250,15 @@ Building an Athena Query
 * Examples:
     1. **athena_cost_and_usage** This should match your table name in Athena.
     2. **bill_billing_entity** Used to filter specific billing entities.
-    3. **line_item_legal_entity** Used to filter specifc legal entities.
+    3. **line_item_legal_entity** Used to filter specific legal entities.
     4. **line_item_line_item_description** Used to filter on specific line item descriptions.
     5. **year** Used to filter to a specific billing year.
     6. **month** Used to filter on a specific billing month.
-* See the following example queires for HCS spend or RHEL ELS subscriptions.
+* See the following example queries for HCS spend or RHEL ELS subscriptions.
     * The table name **athena_cost_and_usage** MUST be updated to match the name of your configured Athena table.
     * The **year** and **month** can be updated to gather data specific to a particular month.
 
-* The below example query will return filtered data specific for your Hybrid Commited Spend commitment.
+* The below example query will return filtered data specific for your Hybrid Committed Spend commitment.
 
 .. code-block::
 

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -128,8 +128,9 @@ Adding Vault Creds To functions
 
 Function Code and Queries
 =========================
-* For standard Hybrid Commited Spend queries use the default `azure_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/azure/scripts/azure-function.txt>`_
-* For custom queries non HCS we need to edit line 53 in the above function code.
+* The default script has the option of Hybrid commited spend or RHEL subscription filtering `azure_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/azure/scripts/azure-function-hcs.txt>`_
+    * All you need to do is uncomment the relevant line, either `filtered_data = hcs_filtering(df)` OR `filtered_data = rhel_filtering(df)` NOT both
+* For custom queries you will need to write your own filtering.
     * Initial query to grab all data: **filtered_data = df**
     * To filter the data you need to add some dataframe filtering, see Examples:
         * Exact matching: **df.loc[(df["publisherType"] == "Marketplace")]** would filter out all data that does not have a publisherType of Marketplace.

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -9,6 +9,7 @@ Azure resource group and storage account
 *Prerequisites:*
     - A console.redhat.com service account is required
     - The service account must have the correct roles assigned in C.R.C for Cost management access
+    - Filtered CSV files *MUST* have the required columns as defined in `Azure filtering required columns`_
 
 1. Create new resource group and storage account for filtered reports using these `instructions <https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_
 
@@ -133,13 +134,78 @@ Function Code and Queries
 * For custom queries you will need to write your own filtering.
     * Initial query to grab all data: **filtered_data = df**
     * To filter the data you need to add some dataframe filtering, see Examples:
-        * Exact matching: **df.loc[(df["publisherType"] == "Marketplace")]** would filter out all data that does not have a publisherType of Marketplace.
-        * Contains: **df.loc[df["publisherName"].astype(str).str.contains("Red Hat")]** would filter all data that does not contain Red Hat in the publisherName.
+        * Exact matching: **df.loc[(df["publishertype"] == "Marketplace")]** would filter out all data that does not have a publisherType of Marketplace.
+        * Contains: **df.loc[df["publishername"].astype(str).str.contains("Red Hat")]** would filter all data that does not contain Red Hat in the publisherName.
     * It's also possible to stack these by using **&** (for AND) and **|** (for OR) with your **df.loc** clause.
     * Examples:
-        1. **subscriptionId** Used to filter specific subscriptions.
-        2. **resourceGroup** Used to filter specific resource groups.
-        3. **resourceLocation** Used to filter data in a specifc region.
-        4. **resourceType**, **instanceId** Used to filter resource types or by a specifc instance.
-        5. **serviceName**, **serviceTier**, **meterCategory** and **meterSubcategory** can be used to filter specifc service types.
+        1. **subscriptionid** Used to filter specific subscriptions.
+        2. **resourcegroup** Used to filter specific resource groups.
+        3. **resourcelocation** Used to filter data in a specifc region.
+        4. **resourcetype** Used to filter resource types.
+        5. **servicename**, **servicetier**, **metercategory** and **metersubcategory** can be used to filter specifc service types.
     * Once your custom query is built just replace line 53 with your revised version.
+
+Azure filtering required columns
+================================
+
+* Below is a list of columns that *MUST* be included and populated for Cost management to process the report correctly
+* These columns *MUST* not include spaces, dashes, underscores and *MUST* be in lower case
+
+    ..code block:
+
+    'accountname',
+    'accountownerid',
+    'additionalinfo',
+    'availabilityzone',
+    'billingaccountid',
+    'billingaccountname',
+    'billingcurrency',
+    'billingperiodenddate',
+    'billingperiodstartdate',
+    'billingprofileid',
+    'billingprofilename',
+    'chargetype',
+    'consumedservice',
+    'costcenter',
+    'costinbillingcurrency',
+    'date',
+    'effectiveprice',
+    'frequency',
+    'invoicesectionid',
+    'invoicesectionname',
+    'isazurecrediteligible',
+    'metercategory',
+    'meterid',
+    'metername',
+    'meterregion',
+    'metersubcategory',
+    'offerid',
+    'partnumber',
+    'paygprice',
+    'planname',
+    'pricingmodel',
+    'productname',
+    'productorderid',
+    'productordername',
+    'publishername',
+    'publishertype',
+    'quantity',
+    'reservationid',
+    'reservationname',
+    'resourcegroup',
+    'resourceid',
+    'resourcelocation',
+    'resourcename',
+    'resourcerate',
+    'resourcetype',
+    'servicefamily',
+    'serviceinfo1',
+    'serviceinfo2',
+    'servicename',
+    'servicetier',
+    'subscriptionid',
+    'subscriptionname',
+    'tags',
+    'term',
+    'unitofmeasure',
+    'unitprice'

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -153,40 +153,24 @@ Azure filtering required columns
 
     ..code block:
 
-    'accountname',
-    'accountownerid',
     'additionalinfo',
-    'availabilityzone',
     'billingaccountid',
     'billingaccountname',
     'billingcurrency',
     'billingperiodenddate',
     'billingperiodstartdate',
-    'billingprofileid',
-    'billingprofilename',
     'chargetype',
     'consumedservice',
-    'costcenter',
     'costinbillingcurrency',
     'date',
     'effectiveprice',
-    'frequency',
-    'invoicesectionid',
-    'invoicesectionname',
-    'isazurecrediteligible',
     'metercategory',
     'meterid',
     'metername',
     'meterregion',
     'metersubcategory',
     'offerid',
-    'partnumber',
-    'paygprice',
-    'planname',
-    'pricingmodel',
     'productname',
-    'productorderid',
-    'productordername',
     'publishername',
     'publishertype',
     'quantity',
@@ -196,17 +180,11 @@ Azure filtering required columns
     'resourceid',
     'resourcelocation',
     'resourcename',
-    'resourcerate',
-    'resourcetype',
     'servicefamily',
     'serviceinfo1',
     'serviceinfo2',
-    'servicename',
-    'servicetier',
     'subscriptionid',
-    'subscriptionname',
     'tags',
-    'term',
     'unitofmeasure',
     'unitprice'
 
@@ -214,4 +192,4 @@ Azure filtering required columns
 
     ..code block:
 
-    column_translation = {"billingcurrencycode": "billingcurrency", "currency": "billingcurrency", "instanceid": "resourceid", "instancename": "resourceid", "pretaxcost": "costinbillingcurrency", "product": "productname", "resourcegroupname": "resourcegroup", "subscriptionguid": "subscriptionid", "usage_quantity": "quantity"}
+    column_translation = {"billingcurrencycode": "billingcurrency", "currency": "billingcurrency", "instanceid": "resourceid", "instancename": "resourceid", "pretaxcost": "costinbillingcurrency", "product": "productname", "resourcegroupname": "resourcegroup", "subscriptionguid": "subscriptionid", "servicename": "metercategory", "usage_quantity": "quantity"}

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -129,7 +129,7 @@ Adding Vault Creds To functions
 
 Function Code and Queries
 =========================
-* The default script has the option of Hybrid commited spend or RHEL subscription filtering `azure_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/azure/scripts/azure-function-hcs.txt>`_
+* The default script has the option of Hybrid commited spend or RHEL subscription filtering `azure_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/azure/scripts/azure-function.txt>`_
     * All you need to do is uncomment the relevant line, either `filtered_data = hcs_filtering(df)` OR `filtered_data = rhel_filtering(df)` NOT both
 * For custom queries you will need to write your own filtering.
     * Initial query to grab all data: **filtered_data = df**
@@ -209,3 +209,9 @@ Azure filtering required columns
     'term',
     'unitofmeasure',
     'unitprice'
+
+* Some of these required columns differ depending on the base report type in use, the example script handles these differences already with the following:
+
+    ..code block:
+
+    column_translation = {"billingcurrencycode": "billingcurrency", "currency": "billingcurrency", "instanceid": "resourceid", "instancename": "resourceid", "pretaxcost": "costinbillingcurrency", "product": "productname", "resourcegroupname": "resourcegroup", "subscriptionguid": "subscriptionid", "usage_quantity": "quantity"}

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -142,7 +142,7 @@ Function Code and Queries
         3. **resourcelocation** Used to filter data in a specifc region.
         4. **resourcetype** Used to filter resource types.
         5. **servicename**, **servicetier**, **metercategory** and **metersubcategory** can be used to filter specifc service types.
-    * Once your custom query is built assign your filtered data to **filtered_data = df[My custom query]**.
+    * Once your custom query is built update the custom query in the example script under  **# custom filtering basic example #**.
 
 Azure filtering required columns
 ================================

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -156,7 +156,7 @@ Azure filtering required columns
     'additionalinfo',
     'billingaccountid',
     'billingaccountname',
-    'billingcurrency',
+    'billingcurrencycode',
     'billingperiodenddate',
     'billingperiodstartdate',
     'chargetype',
@@ -192,4 +192,4 @@ Azure filtering required columns
 
     ..code block:
 
-    column_translation = {"billingcurrencycode": "billingcurrency", "currency": "billingcurrency", "instanceid": "resourceid", "instancename": "resourceid", "pretaxcost": "costinbillingcurrency", "product": "productname", "resourcegroupname": "resourcegroup", "subscriptionguid": "subscriptionid", "servicename": "metercategory", "usage_quantity": "quantity"}
+    column_translation = {"billingcurrency": "billingcurrencycode", "currency": "billingcurrencycode", "instanceid": "resourceid", "instancename": "resourceid", "pretaxcost": "costinbillingcurrency", "product": "productname", "resourcegroupname": "resourcegroup", "subscriptionguid": "subscriptionid", "servicename": "metercategory", "usage_quantity": "quantity"}

--- a/docs/azure/azure.rst
+++ b/docs/azure/azure.rst
@@ -132,7 +132,6 @@ Function Code and Queries
 * The default script has the option of Hybrid commited spend or RHEL subscription filtering `azure_function <https://github.com/project-koku/koku-data-selector/blob/main/docs/azure/scripts/azure-function.txt>`_
     * All you need to do is uncomment the relevant line, either `filtered_data = hcs_filtering(df)` OR `filtered_data = rhel_filtering(df)` NOT both
 * For custom queries you will need to write your own filtering.
-    * Initial query to grab all data: **filtered_data = df**
     * To filter the data you need to add some dataframe filtering, see Examples:
         * Exact matching: **df.loc[(df["publishertype"] == "Marketplace")]** would filter out all data that does not have a publisherType of Marketplace.
         * Contains: **df.loc[df["publishername"].astype(str).str.contains("Red Hat")]** would filter all data that does not contain Red Hat in the publisherName.
@@ -143,7 +142,7 @@ Function Code and Queries
         3. **resourcelocation** Used to filter data in a specifc region.
         4. **resourcetype** Used to filter resource types.
         5. **servicename**, **servicetier**, **metercategory** and **metersubcategory** can be used to filter specifc service types.
-    * Once your custom query is built just replace line 53 with your revised version.
+    * Once your custom query is built assign your filtered data to **filtered_data = df[My custom query]**.
 
 Azure filtering required columns
 ================================

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -35,8 +35,8 @@ def extract_com_redhat_rhel(tags):
 def translate_columns(df):
     # Normalise required columns across differing azure report types
     column_translation = {        
-        "billingcurrencycode": "billingcurrency",
-        "currency": "billingcurrency",
+        "billingcurrency": "billingcurrencycode",
+        "currency": "billingcurrencycode",
         "instanceid": "resourceid", 
         "instancename": "resourceid",
         "pretaxcost": "costinbillingcurrency",

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -32,6 +32,22 @@ def extract_com_redhat_rhel(tags):
         return False
     return False
 
+def translate_columns(df):
+    # Normalise required columns across differing azure report types
+    column_translation = {
+        "subscriptionguid": "subscriptionid",
+        "instancename": "resourceid",
+        "instanceid": "resourceid",
+        "product": "productname",
+        "billingcurrencycode": "billingcurrency",
+        "currency": "billingcurrency",
+        "usage_quantity": "quantity",
+        "resourcegroupname": "resourcegroup",
+        "pretaxcost": "costinbillingcurrency"
+    }
+    df.rename(columns=column_translation, inplace=True)
+    return df
+
 def rhel_filtering(df):
     # Set constants
     tags = "tags"
@@ -61,8 +77,13 @@ def rhel_filtering(df):
     return filtered_df.drop(columns=[rhel_tag, vcpus])
 
 def hcs_filtering(df):
+    # Set constants:
+    ptype = 'publishertype'
+    mscategory = 'metersubcategory'
+    pname = 'publishername'
+
     # Filtering specific to Hybrid Commited Spend
-    return df.loc[((df["publisherType"] == "Azure") & (df["meterSubCategory"].astype(str).str.contains("Red Hat"))) | ((df["publisherType"] == "Marketplace") & ((df["publisherName"].astype(str).str.contains("Red Hat")) | (((df["publisherName"] == "Microsoft") | (df["publisherName"] == "Azure")) & (df["meterSubCategory"].astype(str).str.contains("Red Hat")))))]
+    return df.loc[((df[ptype] == "Azure") & (df[mscategory].astype(str).str.contains("Red Hat"))) | ((df[ptype] == "Marketplace") & ((df[pname].astype(str).str.contains("Red Hat")) | (((df[pname] == "Microsoft") | (df[pname] == "Azure")) & (df[mscategory].astype(str).str.contains("Red Hat")))))]
 
 def main(mytimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -1,5 +1,6 @@
 import datetime
 import calendar
+import json
 import logging
 import os
 import uuid
@@ -11,6 +12,57 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 
 import azure.functions as func
 
+def extract_vcpus(info):
+    # used to extract vcpu details
+        try:
+            json_data = json.loads(info)
+            if isinstance(json_data, dict):
+                return json_data.get('vcpus')
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        return None
+
+def extract_com_redhat_rhel(tags):
+    # used to find rhel metering tags
+    try:
+        json_data = json.loads(tags)
+        if isinstance(json_data, dict):
+            return json_data.get('com_redhat_rhel') is not None
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return False
+    return False
+
+def rhel_filtering(df):
+    # Set constants
+    tags = "tags"
+    additionalinfo = "additionalinfo"
+    vcpus = "vcpus"
+    rhel_tag = "com_redhat_rhel"
+
+    # filtering specific for rhel metering
+    # Filter on Virtual machines
+    df = df[(df["metercategory"].astype(str).str.contains("Virtual Machines"))]
+
+    # Set additional info and tags columns to lower for easier filtering
+    df[additionalinfo] = df[additionalinfo].str.lower()
+    df[tags] = df[tags].str.lower()
+
+    # Extract line items with vcpus and com_redhat_rhel tags
+    df[vcpus] = df[additionalinfo].apply(extract_vcpus)
+    df[rhel_tag] = df[tags].apply(extract_com_redhat_rhel)
+
+    # Convert 'vcpus' to numeric, forcing errors to NaN (in case of any non-numeric values)
+    df[vcpus] = pd.to_numeric(df[vcpus], errors='coerce')
+
+    # Filter rows where 'vcpus' is not null and greater than 0 and 'com_redhat_rhel' is True
+    filtered_df = df[df[vcpus].notnull() & (df[vcpus] > 0) & df[rhel_tag]]
+
+    # Drop the 'com_redhat_rhel' and 'vcpus' columns as they are no longer needed and return the filtered data set
+    return filtered_df.drop(columns=[rhel_tag, vcpus])
+
+def hcs_filtering(df):
+    # Filtering specific to Hybrid Commited Spend
+    return df.loc[((df["publisherType"] == "Azure") & (df["meterSubCategory"].astype(str).str.contains("Red Hat"))) | ((df["publisherType"] == "Marketplace") & ((df["publisherName"].astype(str).str.contains("Red Hat")) | (((df["publisherName"] == "Microsoft") | (df["publisherName"] == "Azure")) & (df["meterSubCategory"].astype(str).str.contains("Red Hat")))))]
 
 def main(mytimer: func.TimerRequest) -> None:
     utc_timestamp = datetime.datetime.utcnow().replace(
@@ -69,8 +121,17 @@ def main(mytimer: func.TimerRequest) -> None:
     with open(blobjct, "wb") as f:
         data.readinto(f)
     df = pd.read_csv(blobjct)
+    # cast columns to lower
+    df.columns = df.columns.str.lower()
 
-    filtered_data = df.loc[((df["publisherType"] == "Azure") & (df["meterSubCategory"].astype(str).str.contains("Red Hat"))) | ((df["publisherType"] == "Marketplace") & ((df["publisherName"].astype(str).str.contains("Red Hat")) | (((df["publisherName"] == "Microsoft") | (df["publisherName"] == "Azure")) & (df["meterSubCategory"].astype(str).str.contains("Red Hat")))))]
+    # You must uncomment either hcs_filtering OR rhel_filtering depending on your usecase NOT BOTH #
+    # If you want to filter different data entirely you will need to build your own *_filtering query #
+
+    # Hybrid Commited Spend filtering #
+    # filtered_data = hcs_filtering(df)
+
+    # RHEL subscriptions filtering #
+    # filtered_data = rhel_filtering(df)
 
     filtered_data_csv = filtered_data.to_csv (index_label="idx", encoding = "utf-8")
 

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -34,17 +34,17 @@ def extract_com_redhat_rhel(tags):
 
 def translate_columns(df):
     # Normalise required columns across differing azure report types
-    column_translation = {
-        "subscriptionguid": "subscriptionid",
-        "instancename": "resourceid",
-        "instanceid": "resourceid",
-        "product": "productname",
+    column_translation = {        
         "billingcurrencycode": "billingcurrency",
         "currency": "billingcurrency",
-        "usage_quantity": "quantity",
+        "instanceid": "resourceid", 
+        "instancename": "resourceid",
+        "pretaxcost": "costinbillingcurrency",
+        "product": "productname",
         "resourcegroupname": "resourcegroup",
-        "pretaxcost": "costinbillingcurrency"
-    }
+        "subscriptionguid": "subscriptionid",
+        "usage_quantity": "quantity"
+        }
     df.rename(columns=column_translation, inplace=True)
     return df
 

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -43,6 +43,7 @@ def translate_columns(df):
         "product": "productname",
         "resourcegroupname": "resourcegroup",
         "subscriptionguid": "subscriptionid",
+        "servicename": "metercategory",
         "usage_quantity": "quantity"
         }
     df.rename(columns=column_translation, inplace=True)

--- a/docs/azure/scripts/azure-function.txt
+++ b/docs/azure/scripts/azure-function.txt
@@ -155,6 +155,9 @@ def main(mytimer: func.TimerRequest) -> None:
     # RHEL subscriptions filtering #
     # filtered_data = rhel_filtering(df)
 
+    # custom filtering basic example #
+    # filtered_data = df.loc[(df["publishertype"] == "Marketplace")] 
+
     filtered_data_csv = filtered_data.to_csv (index_label="idx", encoding = "utf-8")
 
     blob_client = blob_service_client.get_blob_client(container=filtered_data_container, blob=output_blob_name)


### PR DESCRIPTION
This updates and adds the option to filter data based on rhel subscription line items for both AWS and Azure.